### PR TITLE
Add some rater logic unit tests

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+from service.league_service.typedefs import League, LeagueDivision
+
+
+@pytest.fixture
+def example_league():
+    return League(
+        name="example_league",
+        divisions=[
+            LeagueDivision(
+                id=1, min_rating=None, max_rating=100, lowest_score=0, highest_score=10
+            ),
+            LeagueDivision(
+                id=2, min_rating=100, max_rating=200, lowest_score=0, highest_score=10
+            ),
+            LeagueDivision(
+                id=3, min_rating=200, max_rating=None, lowest_score=0, highest_score=10
+            ),
+        ],
+        current_season_id=0,
+        rating_type="global",
+    )

--- a/tests/unit_tests/test_league_datastructure.py
+++ b/tests/unit_tests/test_league_datastructure.py
@@ -1,0 +1,42 @@
+def test_get_player_division(example_league):
+    assert (
+        example_league.get_player_division(division_id=1) is example_league.divisions[0]
+    )
+    assert (
+        example_league.get_player_division(division_id=2) is example_league.divisions[1]
+    )
+    assert (
+        example_league.get_player_division(division_id=3) is example_league.divisions[2]
+    )
+
+
+def test_get_player_division_not_found(example_league):
+    division_id = 999
+    assert example_league.get_player_division(division_id) is None
+
+    # or alternatively, possibly after importing the appropriate Error
+    with pytest.raises(ValueError):
+        example_league.get_player_division(division_id)
+
+
+def test_get_next_higher_division(example_league):
+    division_id = example_league.divisions[1].id
+    assert (
+        example_league.get_next_higher_division(division_id)
+        is example_league.divisions[2]
+    )
+
+
+def test_get_next_higher_division_already_highest(example_league):
+    division_id = example_league.divisions[-1].id
+    assert example_league.get_next_higher_division(division_id) is None
+
+
+def test_get_accumulated_score(example_league):
+    division_id = example_league.divisions[1].id
+    score = 5
+
+    total_score = example_league.get_accumulated_score(division_id, score)
+
+    expected_total_score = 15
+    assert total_score == expected_total_score

--- a/tests/unit_tests/test_league_rater.py
+++ b/tests/unit_tests/test_league_rater.py
@@ -1,0 +1,75 @@
+import pytest
+
+from service.league_service.league_rater import LeagueRater
+from service.league_service.typedefs import (
+    GameOutcome,
+    League,
+    LeagueDivision,
+    LeagueScore,
+)
+
+
+@pytest.fixture
+def unplaced_player_score():
+    return LeagueScore(division_id=None, score=None, game_count=10)
+
+
+def test_new_score_victory_no_boost(example_league):
+    current_score = LeagueScore(division_id=2, score=5, game_count=30)
+    player_rating = 150
+
+    new_score = LeagueRater._calculate_new_score(
+        example_league,
+        current_score,
+        GameOutcome.VICTORY,
+        player_rating,
+        example_league.divisions[1],
+    )
+
+    assert new_score.division_id == current_score.division_id
+    assert new_score.game_count == current_score.game_count + 1
+    assert new_score.score == current_score.score + 1
+
+
+def test_new_score_victory_boost(example_league):
+    current_score = LeagueScore(division_id=2, score=5, game_count=30)
+    player_rating = 1500
+
+    new_score = LeagueRater._calculate_new_score(
+        example_league,
+        current_score,
+        GameOutcome.VICTORY,
+        player_rating,
+        example_league.divisions[1],
+    )
+
+    assert new_score.division_id == current_score.division_id
+    assert new_score.game_count == current_score.game_count + 1
+    assert new_score.score == current_score.score + 2
+
+
+def test_placement(example_league, unplaced_player_score):
+    rating = 150
+
+    new_score = LeagueRater._do_placement(example_league, unplaced_player_score, rating)
+
+    assert new_score.division_id == example_league.divisions[1].id
+    assert new_score.score == 5  # TODO: or whatever you expect here
+
+
+def test_placement_high_rating(example_league, unplaced_player_score):
+    rating = 1500
+
+    new_score = LeagueRater._do_placement(example_league, unplaced_player_score, rating)
+
+    assert new_score.division_id == example_league.divisions[-1].id
+    assert new_score.score > 100  # TODO: or whatever you expect here
+
+
+def test_placement_low_rating(example_league, unplaced_player_score):
+    rating = -500
+
+    new_score = LeagueRater._do_placement(example_league, unplaced_player_score, rating)
+
+    assert new_score.division_id == example_league.divisions[0].id
+    assert new_score.score == 0  # TODO: or whatever you expect here

--- a/tests/unit_tests/test_league_service.py
+++ b/tests/unit_tests/test_league_service.py
@@ -89,7 +89,11 @@ async def test_update_data(uninitialized_service):
         100,
         200,
     ]
-    assert [division.max_rating for division in test_league.divisions] == [100, 200, None]
+    assert [division.max_rating for division in test_league.divisions] == [
+        100,
+        200,
+        None,
+    ]
     assert [division.highest_score for division in test_league.divisions] == [
         10,
         10,


### PR DESCRIPTION
Hope these serve as examples for how to do unit tests.

Some black magic:
1. Both test files and then functions containing the actual tests should start with `test_` so that `pytest` discovers them correctly.
2. The `conftest.py` file will automatically be imported.

The arguments of test functions are "fixtures" like the `example_league`, marked with `@pytest.fixture`,
then they will be freshly built for every new test and if something in the fixture fails, then the test is not "FAILED", but "ERRORED".

If you want to check that something throws an appropriate error, you can put it in a `with pytest.raises(MyError):` block.