### PR TITLE
Handle NULL scores before placement

### DIFF
--- a/league_table_migration.sql
+++ b/league_table_migration.sql
@@ -1,3 +1,6 @@
+DROP TABLE IF EXISTS league_season_score;
+DROP TABLE IF EXISTS league_season_division;
+DROP TABLE IF EXISTS league_season;
 DROP TABLE IF EXISTS league_rating_range;
 DROP TABLE IF EXISTS league_schedule;
 DROP TABLE IF EXISTS league;
@@ -31,9 +34,9 @@ CREATE TABLE league_season_division
   division_index    SMALLINT(5) UNSIGNED  NOT NULL,
   name_key          VARCHAR(255)          NOT NULL,
   description_key   VARCHAR(255)          NOT NULL COMMENT "The division's i18n flavor text key",
-  min_rating        FLOAT,
-  max_rating        FLOAT,
-  highest_score     INT,
+  min_rating        FLOAT                 NOT NULL,
+  max_rating        FLOAT                 NOT NULL,
+  highest_score     INT                   NOT NULL,
   FOREIGN KEY (league_season_id) REFERENCES league_season (id)
 );
 
@@ -41,8 +44,8 @@ CREATE TABLE league_season_score
 (
   login_id          MEDIUMINT(8) UNSIGNED NOT NULL,
   league_season_id  MEDIUMINT(8) UNSIGNED NOT NULL,
-  division_id       INT(10) UNSIGNED      NOT NULL,
-  score             INT                   NOT NULL,
+  division_id       INT(10) UNSIGNED,
+  score             INT,
   game_count        INT                   NOT NULL DEFAULT 0,
   PRIMARY KEY (login_id, league_season_id),
   FOREIGN KEY (login_id) REFERENCES login (id),

--- a/service/league_service/league_rater.py
+++ b/service/league_service/league_rater.py
@@ -34,10 +34,11 @@ class LeagueRater:
             return cls._do_placement(league, current_score, rating)
 
         player_div = league.get_division(current_score.division_id)
-        if player_div is None:
+        if player_div is None or current_score.score is None:
             cls._logger.warning(
-                "Doing placement again, because a division for id %s could not be found.",
-                current_score.division_id,
+                "Doing placement again, because a division not found or score set to null. "
+                "Current league score: %s",
+                current_score,
             )
             return cls._do_placement(league, current_score, rating)
 

--- a/service/league_service/league_rater.py
+++ b/service/league_service/league_rater.py
@@ -36,7 +36,7 @@ class LeagueRater:
         player_div = league.get_division(current_score.division_id)
         if player_div is None or current_score.score is None:
             cls._logger.warning(
-                "Doing placement again, because a division not found or score set to null. "
+                "Doing placement again, because the division was not found or the score set to null. "
                 "Current league score: %s",
                 current_score,
             )

--- a/service/league_service/typedefs.py
+++ b/service/league_service/typedefs.py
@@ -95,9 +95,10 @@ class LeagueScore(NamedTuple):
     score: int
     game_count: int
 
-    def __eq__(self, other: "LeagueScore") -> bool:
+    def __eq__(self, other) -> bool:
         return (
-            self.division_id == other.division_id
+            type(self) == type(other)
+            and self.division_id == other.division_id
             and self.score == other.score
             and self.game_count == other.game_count
         )

--- a/service/league_service/typedefs.py
+++ b/service/league_service/typedefs.py
@@ -12,7 +12,13 @@ class ServiceNotReadyError(LeagueServiceError):
     pass
 
 
-class DivisionDoesNotExistError(Exception):
+class DivisionDoesNotExistError(LeagueServiceError):
+    pass
+
+
+class InvalidScoreError(LeagueServiceError):
+    """Raised when trying to persist a malformed score."""
+
     pass
 
 
@@ -88,6 +94,13 @@ class LeagueScore(NamedTuple):
     division_id: int
     score: int
     game_count: int
+
+    def __eq__(self, other: "LeagueScore") -> bool:
+        return (
+            self.division_id == other.division_id
+            and self.score == other.score
+            and self.game_count == other.game_count
+        )
 
 
 class LeagueRatingRequest(NamedTuple):

--- a/tests/data/test-league-data.sql
+++ b/tests/data/test-league-data.sql
@@ -14,12 +14,12 @@ INSERT INTO league_season (id, league_id, leaderboard_id, start_date, end_date) 
   (3, 2, 2, NOW() - interval 2 year, NULL);
 
 INSERT INTO league_season_division (id, league_season_id, division_index, name_key, description_key, min_rating, max_rating, highest_score) VALUES
-  (1, 1, 1, "name_key", "description_key", NULL, 150, 10),
-  (2, 1, 2, "name_key", "description_key", 150, NULL, NULL),
-  (3, 2, 1, "name_key", "description_key", NULL, 100, 10),
+  (1, 1, 1, "name_key", "description_key", 0, 150, 10),
+  (2, 1, 2, "name_key", "description_key", 150, 3000, 10),
+  (3, 2, 1, "name_key", "description_key", 0, 100, 10),
   (4, 2, 2, "name_key", "description_key", 100, 200, 10),
-  (5, 2, 3, "name_key", "description_key", 200, NULL, NULL),
-  (6, 3, 1, "name_key", "description_key", NULL, NULL, NULL);
+  (5, 2, 3, "name_key", "description_key", 200, 3000, 10),
+  (6, 3, 1, "name_key", "description_key", 0, 3000, 10);
 
 INSERT INTO league_season_score (login_id, league_season_id, division_id, score, game_count) VALUES
   (1, 1, 1, 5, 5),

--- a/tests/integration_tests/test_league_request_rating.py
+++ b/tests/integration_tests/test_league_request_rating.py
@@ -1,0 +1,85 @@
+import pytest
+
+from service.league_service import LeagueService
+from service.league_service.typedefs import LeagueScore
+
+
+@pytest.fixture
+async def league_service(database, message_queue_service):
+    service = LeagueService(database, message_queue_service)
+    await service.initialize()
+    yield service
+    service.kill()
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def test_rate_new_player(league_service):
+    new_player_id = 50
+    rating_type = "global"
+    rating_change_message = {
+        "player_id": new_player_id,
+        "rating_type": rating_type,
+        "new_rating_mean": 1200,
+        "new_rating_deviation": 200,
+        "game_id": 1,
+        "outcome": "VICTORY",
+    }
+
+    await league_service.enqueue(rating_change_message)
+    await league_service._join_queue()
+
+    league_season_id = league_service._leagues_by_rating_type[rating_type][
+        0
+    ].current_season_id
+    saved_score = await league_service._load_score(new_player_id, league_season_id)
+    assert saved_score == LeagueScore(None, None, 1)
+
+
+async def test_rate_new_player_twice(league_service):
+    new_player_id = 50
+    rating_type = "global"
+
+    for game_nbr in range(2):
+        rating_change_message = {
+            "player_id": new_player_id,
+            "rating_type": rating_type,
+            "new_rating_mean": 1200,
+            "new_rating_deviation": 200,
+            "game_id": game_nbr,
+            "outcome": "VICTORY",
+        }
+        await league_service.enqueue(rating_change_message)
+    await league_service._join_queue()
+
+    league_season_id = league_service._leagues_by_rating_type[rating_type][
+        0
+    ].current_season_id
+    saved_score = await league_service._load_score(new_player_id, league_season_id)
+    assert saved_score == LeagueScore(None, None, 2)
+
+
+async def test_rate_new_player_until_placement(league_service):
+    new_player_id = 50
+    rating_type = "global"
+
+    for game_nbr in range(10):
+        rating_change_message = {
+            "player_id": new_player_id,
+            "rating_type": rating_type,
+            "new_rating_mean": 1200,
+            "new_rating_deviation": 200,
+            "game_id": game_nbr,
+            "outcome": "VICTORY",
+        }
+        await league_service.enqueue(rating_change_message)
+    await league_service._join_queue()
+
+    league_season_id = league_service._leagues_by_rating_type[rating_type][
+        0
+    ].current_season_id
+    saved_score = await league_service._load_score(new_player_id, league_season_id)
+    assert saved_score.game_count == 10
+    assert saved_score.division_id is not None
+    assert saved_score.score is not None

--- a/tests/unit_tests/test_league_rater.py
+++ b/tests/unit_tests/test_league_rater.py
@@ -148,6 +148,37 @@ def test_replacement_at_invalid_player_division(example_league):
     assert new_score.score == 5
 
 
+def test_replacement_at_null_division(example_league):
+    current_score = LeagueScore(
+        division_id=None, score=4, game_count=config.PLACEMENT_GAMES
+    )
+    rating = (150.0 - config.RATING_MODIFIER_FOR_PLACEMENT, 0.0)
+
+    new_score = LeagueRater.rate(
+        example_league, current_score, GameOutcome.DRAW, rating
+    )
+
+    assert new_score.division_id == example_league.divisions[1].id
+    assert new_score.game_count == current_score.game_count + 1
+    assert new_score.score == 5
+
+
+def test_replacement_at_null_score(example_league):
+    expected_division_id = example_league.divisions[1].id
+    current_score = LeagueScore(
+        division_id=expected_division_id, score=None, game_count=config.PLACEMENT_GAMES
+    )
+    rating = (150.0 - config.RATING_MODIFIER_FOR_PLACEMENT, 0.0)
+
+    new_score = LeagueRater.rate(
+        example_league, current_score, GameOutcome.DRAW, rating
+    )
+
+    assert new_score.division_id == expected_division_id
+    assert new_score.game_count == current_score.game_count + 1
+    assert new_score.score == 5
+
+
 def test_placement(example_league, unplaced_player_score):
     # Neutralize the offset in the placement function so we can test the score independently of the config settings
     rating = 150 - config.RATING_MODIFIER_FOR_PLACEMENT


### PR DESCRIPTION
Make sure players' game_count is saved correctly before they are placed. This requires saving `LeagueScores` with `division_id` and `score` set to `None` for players who haven't been placed yet.

Also needed to adjust the  database schema to the new league_rater conventions: 
In `league_season_division` min_rating, max_rating, highest_score may not be null, so that comparisons in the rater don't fail.
In `league_season_score` division and score may now be null to save score before placement.

I don't like that we currently have to enforce some data consistency on write, since `league_season_score` carries both a `season_id` and a `division_id`, which has its own `season_id` attached. It would be better not to duplicate this information.
The plain `season_id` is needed to be able to store scores without division before placement.

Closes #4 