### PR TITLE
Add division/subdivision split to db

### DIFF
--- a/league_table_migration.sql
+++ b/league_table_migration.sql
@@ -1,4 +1,5 @@
 DROP TABLE IF EXISTS league_season_score;
+DROP TABLE IF EXISTS league_season_subdivision;
 DROP TABLE IF EXISTS league_season_division;
 DROP TABLE IF EXISTS league_season;
 DROP TABLE IF EXISTS league_rating_range;
@@ -34,21 +35,31 @@ CREATE TABLE league_season_division
   division_index    SMALLINT(5) UNSIGNED  NOT NULL,
   name_key          VARCHAR(255)          NOT NULL,
   description_key   VARCHAR(255)          NOT NULL COMMENT "The division's i18n flavor text key",
+  FOREIGN KEY (league_season_id) REFERENCES league_season (id)
+);
+
+CREATE TABLE league_season_division_subdivision
+(
+  id                INT(10) UNSIGNED      NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  league_season_division_id  INT(10) UNSIGNED NOT NULL,
+  subdivision_index    SMALLINT(5) UNSIGNED  NOT NULL,
+  name_key          VARCHAR(255)          NOT NULL,
+  description_key   VARCHAR(255)          NOT NULL COMMENT "The subdivision's i18n flavor text key",
   min_rating        FLOAT                 NOT NULL,
   max_rating        FLOAT                 NOT NULL,
   highest_score     INT                   NOT NULL,
-  FOREIGN KEY (league_season_id) REFERENCES league_season (id)
+  FOREIGN KEY (league_season_division_id) REFERENCES league_season_division (id)
 );
 
 CREATE TABLE league_season_score
 (
   login_id          MEDIUMINT(8) UNSIGNED NOT NULL,
   league_season_id  MEDIUMINT(8) UNSIGNED NOT NULL,
-  division_id       INT(10) UNSIGNED,
+  subdivision_id       INT(10) UNSIGNED,
   score             INT,
   game_count        INT                   NOT NULL DEFAULT 0,
   PRIMARY KEY (login_id, league_season_id),
   FOREIGN KEY (login_id) REFERENCES login (id),
-  FOREIGN KEY (division_id) REFERENCES league_season_division (id),
+  FOREIGN KEY (subdivision_id) REFERENCES league_season_division_subdivision (id),
   UNIQUE INDEX (login_id, score, league_season_id)
 );

--- a/service/db/models.py
+++ b/service/db/models.py
@@ -48,6 +48,16 @@ league_season_division = Table(
     Column("id", Integer, primary_key=True),
     Column("league_season_id", Integer, ForeignKey("league_season.id")),
     Column("division_index", Integer),
+)
+
+league_season_division_subdivision = Table(
+    "league_season_division_subdivision",
+    metadata,
+    Column("id", Integer, primary_key=True),
+    Column(
+        "league_season_division_id", Integer, ForeignKey("league_season_division.id")
+    ),
+    Column("subdivision_index", Integer),
     Column("min_rating", Float),
     Column("max_rating", Float),
     Column("highest_score", Integer),
@@ -58,7 +68,9 @@ league_season_score = Table(
     metadata,
     Column("login_id", Integer, ForeignKey("login.id")),
     Column("league_season_id", Integer, ForeignKey("league_season.id")),
-    Column("division_id", Integer, ForeignKey("league_season_division.id")),
+    Column(
+        "subdivision_id", Integer, ForeignKey("league_season_division_subdivision.id")
+    ),
     Column("score", Integer),
     Column("game_count", Integer),
 )

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -343,21 +343,4 @@ insert into mod_version_review (id, text, user_id, score, mod_version_id) VALUES
   (2, 'Like it', 2, 4, 1),
   (3, 'Funny', 3, 4, 1);
 
-INSERT INTO ladder_division VALUES
-  (1, 'League 1 - Division A', 1, 10.0),
-  (2, 'League 1 - Division B', 1, 30.0),
-  (3, 'League 1 - Division C', 1, 50.0),
-  (4, 'League 2 - Division D', 2, 20.0),
-  (5, 'League 2 - Division E', 2, 60.0),
-  (6, 'League 2 - Division F', 2, 100.0),
-  (7, 'League 3 - Division D', 3, 100.0),
-  (8, 'League 3 - Division E', 3, 200.0),
-  (9, 'League 3 - Division F', 3, 9999.0);
-
-INSERT INTO ladder_division_score (season, user_id, league, score, games) VALUES
-  (1, 1, 1, 9.5, 4),
-  (1, 2, 1, 49.5, 70),
-  (1, 3, 2, 0.0, 39),
-  (1, 4, 3, 10.0, 121);
-
 INSERT INTO email_domain_blacklist VALUES ('spam.org');

--- a/tests/data/test-league-data.sql
+++ b/tests/data/test-league-data.sql
@@ -1,30 +1,41 @@
 DELETE FROM league_season_score;
+DELETE FROM league_season_division_subdivision;
 DELETE FROM league_season_division;
 DELETE FROM league_season;
 DELETE FROM league;
 
 INSERT INTO league (id, technical_name, name_key, description_key) VALUES
-  (1, "test_league", "name_key", "description_key"),
-  (2, "second_test_league", "name_key", "description_key"),
-  (3, "league_without_seasons", "name_key", "description_key");
+  (1, "test_league", "L1", "description_key"),
+  (2, "second_test_league", "L2", "description_key"),
+  (3, "league_without_seasons", "L3", "description_key");
 
 INSERT INTO league_season (id, league_id, leaderboard_id, start_date, end_date) VALUES
   (1, 1, 1, NOW() - interval 2 year, NOW() - interval 1 year),
   (2, 1, 1, NOW() - interval 1 year, NULL),
   (3, 2, 2, NOW() - interval 2 year, NULL);
 
-INSERT INTO league_season_division (id, league_season_id, division_index, name_key, description_key, min_rating, max_rating, highest_score) VALUES
-  (1, 1, 1, "name_key", "description_key", 0, 150, 10),
-  (2, 1, 2, "name_key", "description_key", 150, 3000, 10),
-  (3, 2, 1, "name_key", "description_key", 0, 100, 10),
-  (4, 2, 2, "name_key", "description_key", 100, 200, 10),
-  (5, 2, 3, "name_key", "description_key", 200, 3000, 10),
-  (6, 3, 1, "name_key", "description_key", 0, 3000, 10);
+INSERT INTO league_season_division (id, league_season_id, division_index, name_key, description_key) VALUES
+  (1, 1, 1, "L1D1", "description_key"),
+  (2, 1, 2, "L1D2", "description_key"),
+  (3, 2, 1, "L2D1", "description_key"),
+  (4, 2, 2, "L2D2", "description_key"),
+  (5, 2, 3, "L2D3", "description_key"),
+  (6, 3, 1, "L3D1", "description_key");
 
-INSERT INTO league_season_score (login_id, league_season_id, division_id, score, game_count) VALUES
+INSERT INTO league_season_division_subdivision (id, league_season_division_id, subdivision_index, name_key, description_key, min_rating, max_rating, highest_score) VALUES
+  (1, 1, 1, "L1D1S1", "description_key", 0, 150, 10),
+  (2, 2, 1, "L1D2S1", "description_key", 150, 3000, 10),
+  (3, 3, 1, "L2D1S1", "description_key", 0, 100, 10),
+  (4, 3, 2, "L2D1S2", "description_key", 100, 200, 10),
+  (5, 4, 1, "L2D2S1", "description_key", 200, 300, 10),
+  (6, 4, 2, "L2D2S2", "description_key", 300, 400, 10),
+  (7, 5, 1, "L2D3S1", "description_key", 400, 500, 10),
+  (8, 5, 2, "L2D3S2", "description_key", 500, 600, 100),
+  (9, 6, 1, "L3D1S1", "description_key", 0, 3000, 10);
+
+INSERT INTO league_season_score (login_id, league_season_id, subdivision_id, score, game_count) VALUES
   (1, 1, 1, 5, 5),
-  (1, 2, 4, 3, 15),
-  (1, 3, 6, 1200, 120),
+  (1, 2, 5, 3, 15),
+  (1, 3, 9, 1200, 120),
   (2, 1, 2, 0, 15),
-  (3, 2, 5, 5, 5);
-
+  (3, 2, 8, 5, 5);

--- a/tests/unit_tests/test_league_service.py
+++ b/tests/unit_tests/test_league_service.py
@@ -83,24 +83,37 @@ async def test_update_data(uninitialized_service):
     test_league = service._leagues_by_rating_type["global"][0]
     assert test_league.current_season_id == 2
     assert test_league.rating_type == "global"
-    assert len(test_league.divisions) == 3
-    assert [division.min_rating for division in test_league.divisions] == [0, 100, 200]
+    assert len(test_league.divisions) == 6
+    assert [division.min_rating for division in test_league.divisions] == [
+        0,
+        100,
+        200,
+        300,
+        400,
+        500,
+    ]
     assert [division.max_rating for division in test_league.divisions] == [
         100,
         200,
-        3000,
+        300,
+        400,
+        500,
+        600,
     ]
     assert [division.highest_score for division in test_league.divisions] == [
         10,
         10,
         10,
+        10,
+        10,
+        100,
     ]
 
 
 async def test_load_score(league_service):
     player_id = 1
     league_season_id = 2
-    expected_division_id = 4
+    expected_division_id = 5
     expected_score = 3
     expected_game_count = 15
 


### PR DESCRIPTION
Add one more table to database scheme to group subdivisions by division.
This way, a division can have a shared name key between all its subdivisions,
e.g. division "Silver" has subdivisions "I", "II", and "III", which will then be displayed as "Silver I" (etc.) in the client.
This also simplifies graphing of score over time where one would like to group by division.

These changes only touch the league rating service where it is concerned with loading division data for each league.
Subdivisions are still represented as a flat list of independent divisions for rating purposes, so nothing changes and the rater is not aware of division boundaries.

Closes #5 

[Merge is currently pointing to `issue/#004-handle-new-players` so that the diffs make more sense, should merge the other PR first and then point this one at `develop`.]