### PR TITLE
Add configuration option for name of durable queue receiving game results

### DIFF
--- a/service/config.py
+++ b/service/config.py
@@ -23,6 +23,7 @@ MQ_PREFETCH_COUNT = int(os.getenv("MQ_PREFETCH_COUNT", 300))
 
 
 EXCHANGE_NAME = os.getenv("EXCHANGE_NAME", "faf-rabbitmq")
+QUEUE_NAME = os.getenv("QUEUE_NAME", "faf-league-service")
 LEAGUE_REQUEST_ROUTING_KEY = os.getenv(
     "LEAGUE_REQUEST_ROUTING_KEY", "success.gameResults.create"
 )

--- a/service/message_queue_service.py
+++ b/service/message_queue_service.py
@@ -131,7 +131,7 @@ class MessageQueueService:
         if exchange_name not in self._exchanges:
             await self.declare_exchange(exchange_name, exchange_type)
 
-        queue = await self._channel.declare_queue("", exclusive=True, durable=True)
+        queue = await self._channel.declare_queue(config.QUEUE_NAME, exclusive=True, durable=True)
 
         await queue.bind(exchange=exchange_name, routing_key=routing_key)
 


### PR DESCRIPTION
To receive new game results from rabbitMQ we make a new queue listening to all relevant messages. That queue is "durable" so that it stays in place and continues to collect messages if the service shuts down briefly. We would then want to connect to the same queue again, but unfortunately I left the queue name at the default, which is just a random name - so it will be different every time.
I am told if your durable queue has a random name you "lose your shit" and that makes a lot of sense, so this makes the name fixed (but configurable)
Closes #13 