### PR TITLE
Add Schemaspy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,5 +37,5 @@ deploy:
   github_token: $GITHUB_PAGES_TOKEN
   keep_history: false
   on:
-    branch: develop
+    branch: add-schemaspy
   local_dir: ./public 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,12 @@ script:
 
 after_success:
   - coveralls
+
+deploy:
+  provider: pages
+  skip_cleanup: true
+  github_token: $GITHUB_PAGES_TOKEN
+  keep_history: false
+  on:
+    branch: develop
+  local_dir: ./public 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
 
 after_success:
   - coveralls
+  - ./ci/schemaspy.sh
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ deploy:
   github_token: $GITHUB_PAGES_TOKEN
   keep_history: false
   on:
-    branch: add-schemaspy
+    branch: develop
   local_dir: ./public 

--- a/ci/schemaspy.properties
+++ b/ci/schemaspy.properties
@@ -1,0 +1,8 @@
+schemaspy.t=mysql
+schemaspy.host=faf-db
+schemaspy.port=3306
+schemaspy.db=faf-league
+schemaspy.u=root
+schemaspy.p=banana
+schemaspy.outputDirectory=/output
+schemaspy.s=faf-league

--- a/ci/schemaspy.sh
+++ b/ci/schemaspy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+echo 'travis_fold:start:schemaspy'
+
+echo '# Generating db diagram with Schemaspy'
+
+SCHEMASPY_OUTPUT_DIR=$PWD/public
+
+cat "$PWD/ci/schemaspy.properties"
+
+mkdir -p "${SCHEMASPY_OUTPUT_DIR}"
+chmod a+rw "${SCHEMASPY_OUTPUT_DIR}"
+
+docker run --network="faf" \
+            -v "$PWD/ci/schemaspy.properties:/schemaspy.properties" \
+            -v "${SCHEMASPY_OUTPUT_DIR}:/output" \
+            schemaspy/schemaspy:latest \
+           || { echo "Could not generate schema"; exit 1; }
+
+echo 'travis_fold:end:schemaspy'


### PR DESCRIPTION
Closes #10

There isn't really much to review, since this is exactly what's done in the faf-db repo modulo a few name changes; it only took me some time to understand the setup and settings necessary to actually get the results up on github-pages.

I assume there's no good way to integrate this with the schemaspy page of faf-db, but let me know if you imagined something different, Brutus.