### PR TITLE
Fix local setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           MYSQL_PASSWORD: banana
 
       faf-rabbitmq:
-        image: rabbitmq:3-alpine
+        image: rabbitmq:3.8-management-alpine
         ports:
           - 5672:5672
         options: >-

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and running `scripts/init-db.sh` should set this up.
 
 
 Additionally, the service needs a running RabbitMQ server, which can be started
-via docker by running `ci/init-rabbitmq.sh`.
+via docker by running `scripts/local-rabbitmq.sh`.
 This starts a RabbitMQ server on vhost `/faf-lobby`.
 
 ## Setting up for development

--- a/scripts/local_rabbitmq.sh
+++ b/scripts/local_rabbitmq.sh
@@ -9,7 +9,7 @@ RABBITMQ_LEAGUE_SERVICE_USER=faf-league-service
 RABBITMQ_LEAGUE_SERVICE_PASS=banana
 RABBITMQ_LEAGUE_SERVICE_VHOST=/faf-lobby
 
-docker run -d -p 5672:5672 --restart unless-stopped --name faf-rabbitmq rabbitmq:3.8.2-management-alpine
+docker run -d -p 5672:5672 --restart unless-stopped --name faf-rabbitmq rabbitmq:3.8-management-alpine
 
 # This doesn't seem to pick up the pid file
 docker exec faf-rabbitmq rabbitmqctl wait --timeout ${MAX_WAIT_SECONDS} "${RABBITMQ_PID_FILE}"

--- a/scripts/local_rabbitmq.sh
+++ b/scripts/local_rabbitmq.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+RABBITMQ_PID_FILE=/var/lib/rabbitmq/pid
+RABBITMQ_DEFAULT_USER=admin
+RABBITMQ_DEFAULT_PASS=banana
+RABBITMQ_DEFAULT_VHOST=/
+
+docker run --rm -d -p 5672:5672  --name faf-rabbitmq rabbitmq:3.8.2-management-alpine
+
+sh ./.github/workflows/scripts/init-rabbitmq.sh
+

--- a/scripts/local_rabbitmq.sh
+++ b/scripts/local_rabbitmq.sh
@@ -4,8 +4,18 @@ RABBITMQ_PID_FILE=/var/lib/rabbitmq/pid
 RABBITMQ_DEFAULT_USER=admin
 RABBITMQ_DEFAULT_PASS=banana
 RABBITMQ_DEFAULT_VHOST=/
+MAX_WAIT_SECONDS=30
+RABBITMQ_LEAGUE_SERVICE_USER=faf-league-service
+RABBITMQ_LEAGUE_SERVICE_PASS=banana
+RABBITMQ_LEAGUE_SERVICE_VHOST=/faf-lobby
 
-docker run --rm -d -p 5672:5672  --name faf-rabbitmq rabbitmq:3.8.2-management-alpine
+docker run -d -p 5672:5672 --restart unless-stopped --name faf-rabbitmq rabbitmq:3.8.2-management-alpine
 
-sh ./.github/workflows/scripts/init-rabbitmq.sh
+# This doesn't seem to pick up the pid file
+docker exec faf-rabbitmq rabbitmqctl wait --timeout ${MAX_WAIT_SECONDS} "${RABBITMQ_PID_FILE}"
+# Create RabbitMQ users
+docker exec faf-rabbitmq rabbitmqctl add_vhost "${RABBITMQ_LEAGUE_SERVICE_VHOST}"
+docker exec faf-rabbitmq rabbitmqctl add_user "${RABBITMQ_LEAGUE_SERVICE_USER}" "${RABBITMQ_LEAGUE_SERVICE_PASS}"
+docker exec faf-rabbitmq rabbitmqctl set_permissions -p "${RABBITMQ_LEAGUE_SERVICE_VHOST}" "${RABBITMQ_LEAGUE_SERVICE_USER}" ".*" ".*" ".*"
+
 


### PR DESCRIPTION
Closes #37 
I also made the container restart automatically so you don't have to set it up again every time you want to run the unit tests.
However, waiting for the pid file doesn't seem to work. I don't really know why.