### PR TITLE
Add season_number column

### DIFF
--- a/migrations/V010__add_season_number_column.sql
+++ b/migrations/V010__add_season_number_column.sql
@@ -1,7 +1,7 @@
 ALTER table league_season
 ADD COLUMN `season_number` INTEGER NOT NULL AFTER placement_games;
 
-UPDATE league_season SET season_number = 1 WHERE id = 1;
-UPDATE league_season SET season_number = 1 WHERE id = 2;
-UPDATE league_season SET season_number = 2 WHERE id = 3;
-UPDATE league_season SET season_number = 2 WHERE id = 4;
+UPDATE league_season SET season_number = 1, name_key = "2v2_season" WHERE id = 1;
+UPDATE league_season SET season_number = 1, name_key = "1v1_season"  WHERE id = 2;
+UPDATE league_season SET season_number = 2, name_key = "2v2_season"  WHERE id = 3;
+UPDATE league_season SET season_number = 2, name_key = "1v1_season"  WHERE id = 4;

--- a/migrations/V010__add_season_number_column.sql
+++ b/migrations/V010__add_season_number_column.sql
@@ -1,0 +1,7 @@
+ALTER table league_season
+ADD COLUMN `season_number` INTEGER NOT NULL AFTER placement_games;
+
+UPDATE league_season SET season_number = 1 WHERE id = 1;
+UPDATE league_season SET season_number = 1 WHERE id = 2;
+UPDATE league_season SET season_number = 2 WHERE id = 3;
+UPDATE league_season SET season_number = 2 WHERE id = 4;

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -20,11 +20,11 @@ INSERT INTO league (id, technical_name, image_url, medium_image_url, small_image
   (2, "second_test_league", "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L2", "description_key"),
   (3, "league_without_seasons", "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L3", "description_key");
 
-INSERT INTO league_season (id, league_id, leaderboard_id, name_key, start_date, end_date) VALUES
-  (1, 1, 1, "season.1", NOW() - interval 2 year, NOW() - interval 1 year),
-  (2, 1, 1, "season.2", NOW() - interval 1 year, NOW() + interval 1 year),
-  (3, 2, 2, "season.3", NOW() - interval 2 year, NOW() + interval 1 year),
-  (4, 1, 1, "season.4", NOW() + interval 1 year, NOW() + interval 2 year);
+INSERT INTO league_season (id, league_id, leaderboard_id, placement_games, season_number, name_key, start_date, end_date) VALUES
+  (1, 1, 1, 10, 1, "season.1", NOW() - interval 2 year, NOW() - interval 1 year),
+  (2, 1, 1, 10, 2, "season.2", NOW() - interval 1 year, NOW() + interval 1 year),
+  (3, 2, 2, 10, 1, "season.3", NOW() - interval 2 year, NOW() + interval 1 year),
+  (4, 1, 1, 10, 3, "season.4", NOW() + interval 1 year, NOW() + interval 2 year);
 
 INSERT INTO league_season_division (id, league_season_id, division_index, name_key, description_key) VALUES
   (1, 1, 1, "L1D1", "description_key"),


### PR DESCRIPTION
During review of the client ui code we noticed that having the number of the season explicitly stored makes internationalization a lot easier. 

The placement games column was added earlier, but hadn't added it to the test data yet.