### PR TITLE
Remove exclusive queue and and use exclusive consumer

### DIFF
--- a/service/message_queue_service.py
+++ b/service/message_queue_service.py
@@ -131,11 +131,11 @@ class MessageQueueService:
         if exchange_name not in self._exchanges:
             await self.declare_exchange(exchange_name, exchange_type)
 
-        queue = await self._channel.declare_queue(config.QUEUE_NAME, exclusive=True, durable=True)
+        queue = await self._channel.declare_queue(config.QUEUE_NAME, durable=True)
 
         await queue.bind(exchange=exchange_name, routing_key=routing_key)
 
-        await queue.consume(callback)
+        await queue.consume(callback, exclusive=True)
 
     async def reconnect(self) -> None:
         await self.shutdown()

--- a/tests/integration_tests/conftest.py
+++ b/tests/integration_tests/conftest.py
@@ -22,12 +22,13 @@ class Consumer:
         exchange = await channel.declare_exchange(
             config.EXCHANGE_NAME, aio_pika.ExchangeType.TOPIC, durable=True
         )
-        self.queue = await channel.declare_queue("test_queue", exclusive=True)
+        self.queue = await channel.declare_queue("test_queue", durable=True)
 
         await self.queue.bind(exchange, routing_key="#")
-        self.consumer_tag = await self.queue.consume(self.callback)
+        self.consumer_tag = await self.queue.consume(self.callback, exclusive=True)
 
     def callback(self, message):
+        message.ack()
         self.received_messages.append(message)
         self._logger.debug("Received message %r", message)
         self._callback()


### PR DESCRIPTION
The durable and exclusive flags on the queue are mutually exclusive, this prevents us from creating a durable queue which preserves messages during service restart.

The solution is to use a durable queue and an exclusive consumer this will force the queue to be durable but also allow only one consumer on the queue at a time