### PR TITLE
Disable league switch

### DIFF
--- a/migrations/V015__add_league_enable_switch.sql
+++ b/migrations/V015__add_league_enable_switch.sql
@@ -1,5 +1,3 @@
 ALTER table league
-ADD COLUMN `enabled` BOOLEAN NOT NULL DEFAULT TRUE AFTER technical_name
-;
+ADD COLUMN `enabled` BOOLEAN NOT NULL DEFAULT TRUE AFTER technical_name;
 UPDATE league SET enabled = TRUE;
-UPDATE league SET enabled = FALSE WHERE id = 4;

--- a/migrations/V015__add_league_enable_switch.sql
+++ b/migrations/V015__add_league_enable_switch.sql
@@ -1,0 +1,5 @@
+ALTER table league
+ADD COLUMN `enabled` BOOLEAN NOT NULL DEFAULT TRUE AFTER technical_name
+;
+UPDATE league SET enabled = TRUE;
+UPDATE league SET enabled = FALSE WHERE id = 4;

--- a/migrations/V016__disable_4v4_share_until_death_league.sql
+++ b/migrations/V016__disable_4v4_share_until_death_league.sql
@@ -1,0 +1,1 @@
+UPDATE league SET enabled = FALSE WHERE id = 4;

--- a/service/db/models.py
+++ b/service/db/models.py
@@ -17,6 +17,7 @@ league = Table(
     metadata,
     Column("id", Integer, primary_key=True),
     Column("technical_name", String, nullable=False, unique=True),
+    Column("enabled", Boolean, nullable=False),
     Column("image_url", String, nullable=False),
     Column("medium_image_url", String, nullable=False),
     Column("small_image_url", String, nullable=False),

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -15,10 +15,10 @@ insert into leaderboard (id, technical_name) values
   (1, "global"),
   (2, "ladder_1v1");
 
-INSERT INTO league (id, technical_name, image_url, medium_image_url, small_image_url, name_key, description_key) VALUES
-  (1, "test_league", "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L1", "description_key"),
-  (2, "second_test_league", "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L2", "description_key"),
-  (3, "league_without_seasons", "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L3", "description_key");
+INSERT INTO league (id, technical_name, enabled, image_url, medium_image_url, small_image_url, name_key, description_key) VALUES
+  (1, "test_league", TRUE, "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L1", "description_key"),
+  (2, "second_test_league", TRUE,  "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L2", "description_key"),
+  (3, "league_without_seasons", TRUE, "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L3", "description_key");
 
 INSERT INTO league_season (id, league_id, leaderboard_id, placement_games, placement_games_returning_player, season_number, name_key, start_date, end_date) VALUES
   (1, 1, 1, 10, 3, 1, "season.1", NOW() - interval 2 year, NOW() - interval 1 year),


### PR DESCRIPTION
This enables the client to only display leagues that are enabled. I.e. we can finally get rid of the no share league in the client.