### PR TITLE
Fix incorrect returning player results

### DIFF
--- a/service/league_service/league_service.py
+++ b/service/league_service/league_service.py
@@ -179,11 +179,8 @@ class LeagueService:
                 )
             )
             result = await conn.execute(sql)
-            row = result.fetchone()
-        if row is None or row.subdivision_id is None:
-            return False
-        else:
-            return True
+            rows = result.fetchall()
+        return any(row.subdivision_id is not None for row in rows)
 
     async def _persist_score(
         self, game_id: GameID, player_id: PlayerID, season_id: int, old_score: LeagueScore, new_score: LeagueScore

--- a/service/league_service/league_service.py
+++ b/service/league_service/league_service.py
@@ -175,12 +175,14 @@ class LeagueService:
                     and_(
                         league_season_score.c.login_id == player_id,
                         leaderboard.c.technical_name == rating_type,
+                        league_season_score.c.subdivision_id.isnot(None),
                     )
                 )
+                .limit(1)
             )
             result = await conn.execute(sql)
-            rows = result.fetchall()
-        return any(row.subdivision_id is not None for row in rows)
+            row = result.fetchone()
+        return row is not None
 
     async def _persist_score(
         self, game_id: GameID, player_id: PlayerID, season_id: int, old_score: LeagueScore, new_score: LeagueScore

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -52,5 +52,7 @@ INSERT INTO league_season_score (login_id, league_season_id, subdivision_id, sco
   (1, 1, 1, 5, 5, FALSE),
   (1, 2, 5, 3, 15, TRUE),
   (1, 3, 9, 1200, 120, FALSE),
-  (2, 1, 2, 0, 15, FALSE),
+  (2, 1, NULL, NULL, 5, FALSE),
+  (2, 2, 2, 0, 15, FALSE),
   (3, 2, 8, 5, 5, FALSE);
+  (4, 2, NULL, NULL, 3, FALSE),

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -23,36 +23,41 @@ INSERT INTO league (id, technical_name, enabled, image_url, medium_image_url, sm
   (3, "league_without_seasons", TRUE, "https://faf.com/", "https://faf.com/medium/", "https://faf.com/small/", "L3", "description_key");
 
 INSERT INTO league_season (id, league_id, leaderboard_id, placement_games, placement_games_returning_player, season_number, name_key, start_date, end_date) VALUES
-  (1, 1, 1, 10, 3, 1, "test_league.season.1", NOW() - interval 2 week, NOW() - interval 1 week),
-  (2, 1, 1, 10, 3, 2, "test_league.season.2", NOW() - interval 1 week, NOW() + interval 1 week),
-  (3, 2, 2, 10, 3, 1, "second_test_league.season.1", NOW() - interval 2 week, NOW() + interval 1 week),
-  (4, 1, 1, 10, 3, 3, "test_league.season.3", NOW() + interval 1 week, NOW() + interval 2 week);
+  (1, 1, 1, 10, 3, 1, "test_league.season.1", NOW() - interval 3 week, NOW() - interval 2 week),
+  (2, 1, 1, 10, 3, 2, "test_league.season.2", NOW() - interval 2 week, NOW() - interval 1 week),
+  (3, 1, 1, 10, 3, 3, "test_league.season.current", NOW() - interval 1 week, NOW() + interval 1 week),
+  (4, 2, 2, 10, 3, 1, "second_test_league.season.1", NOW() - interval 2 week, NOW() + interval 1 week),
+  (5, 1, 1, 10, 3, 4, "test_league.season.future", NOW() + interval 1 week, NOW() + interval 2 week);
 
 INSERT INTO league_season_division (id, league_season_id, division_index, name_key, description_key) VALUES
-  (1, 1, 1, "L1D1", "description_key"),
-  (2, 1, 2, "L1D2", "description_key"),
-  (3, 2, 1, "L2D1", "description_key"),
-  (4, 2, 2, "L2D2", "description_key"),
-  (5, 2, 3, "L2D3", "description_key"),
-  (6, 3, 1, "L3D1", "description_key"),
-  (7, 3, 2, "L3D2", "description_key");
+  (1, 1, 1, "L1S1D1", "description_key"),
+  (2, 1, 2, "L1S1D2", "description_key"),
+  (3, 2, 1, "L1S2D1", "description_key"),
+  (4, 2, 2, "L1S2D2", "description_key"),
+  (5, 3, 1, "L1S3D1", "description_key"),
+  (6, 3, 2, "L1S3D2", "description_key"),
+  (7, 3, 3, "L1S3D3", "description_key"),
+  (8, 4, 1, "L2S1D1", "description_key"),
+  (9, 4, 2, "L2S1D2", "description_key");
 
 INSERT INTO league_season_division_subdivision (id, league_season_division_id, subdivision_index, name_key, description_key, min_rating, max_rating, highest_score) VALUES
-  (1, 1, 1, "L1D1S1", "description_key", 0, 150, 10),
-  (2, 2, 1, "L1D2S1", "description_key", 150, 3000, 10),
-  (3, 3, 1, "L2D1S1", "description_key", 0, 100, 10),
-  (4, 3, 2, "L2D1S2", "description_key", 100, 200, 10),
-  (5, 4, 1, "L2D2S1", "description_key", 200, 300, 10),
-  (6, 4, 2, "L2D2S2", "description_key", 300, 400, 10),
-  (7, 5, 1, "L2D3S1", "description_key", 400, 500, 10),
-  (8, 5, 2, "L2D3S2", "description_key", 500, 600, 100),
-  (9, 6, 1, "L3D1S1", "description_key", 0, 3000, 20);
+  (1, 1, 1, "L1S1D1SD1", "description_key", 0, 150, 10),
+  (2, 2, 1, "L1S1D2SD1", "description_key", 150, 3000, 10),
+  (3, 3, 1, "L1S2D1SD1", "description_key", 0, 150, 10),
+  (4, 4, 1, "L1S2D2SD1", "description_key", 150, 3000, 10),
+  (5, 5, 1, "L1S3D1SD1", "description_key", 0, 100, 10),
+  (6, 5, 2, "L1S3D1SD2", "description_key", 100, 200, 10),
+  (7, 6, 1, "L1S3D2SD1", "description_key", 200, 300, 10),
+  (8, 6, 2, "L1S3D2SD2", "description_key", 300, 400, 10),
+  (9, 7, 1, "L1S3D3SD1", "description_key", 400, 500, 10),
+  (10, 7, 2, "L1S3D3SD2", "description_key", 500, 600, 100),
+  (11, 8, 1, "L2S1D1SD1", "description_key", 0, 3000, 20);
 
 INSERT INTO league_season_score (login_id, league_season_id, subdivision_id, score, game_count, returning_player) VALUES
   (1, 1, 1, 5, 5, FALSE),
-  (1, 2, 5, 3, 15, TRUE),
-  (1, 3, 9, 1200, 120, FALSE),
+  (1, 3, 7, 3, 15, TRUE),
+  (1, 5, 11, 1200, 120, FALSE),
   (2, 1, NULL, NULL, 5, FALSE),
-  (2, 2, 2, 0, 15, FALSE),
-  (3, 2, 8, 5, 5, FALSE),
+  (2, 2, 4, 0, 15, FALSE),
+  (3, 2, 10, 5, 5, FALSE),
   (4, 2, NULL, NULL, 3, FALSE);

--- a/tests/data/test-data.sql
+++ b/tests/data/test-data.sql
@@ -54,5 +54,5 @@ INSERT INTO league_season_score (login_id, league_season_id, subdivision_id, sco
   (1, 3, 9, 1200, 120, FALSE),
   (2, 1, NULL, NULL, 5, FALSE),
   (2, 2, 2, 0, 15, FALSE),
-  (3, 2, 8, 5, 5, FALSE);
-  (4, 2, NULL, NULL, 3, FALSE),
+  (3, 2, 8, 5, 5, FALSE),
+  (4, 2, NULL, NULL, 3, FALSE);

--- a/tests/unit_tests/test_league_service.py
+++ b/tests/unit_tests/test_league_service.py
@@ -83,7 +83,7 @@ async def test_update_data(uninitialized_service):
 
     assert len(service._leagues_by_rating_type["global"]) == 1
     test_league = service._leagues_by_rating_type["global"][0]
-    assert test_league.current_season_id == 2
+    assert test_league.current_season_id == 3
     assert test_league.rating_type == "global"
     assert len(test_league.divisions) == 6
     assert [division.min_rating for division in test_league.divisions] == [
@@ -140,7 +140,7 @@ async def test_is_not_returning_player(league_service):
 async def test_load_score(league_service):
     player_id = 1
     rating_type = "global"
-    expected_division_id = 5
+    expected_division_id = 7
     expected_score = 3
     expected_game_count = 15
     expected_returning_player = True
@@ -184,8 +184,8 @@ async def test_load_score_league_does_not_exist(league_service):
 async def test_persist_score_new_player(league_service, database):
     game_id = 1
     new_player_id = 5
-    season_id = 2
-    division_id = 3
+    season_id = 3
+    division_id = 5
     score = 6
     game_count = 42
     returning = False
@@ -205,9 +205,9 @@ async def test_persist_score_new_player(league_service, database):
         for row in rows:
             assert row.game_id == 1
             assert row.login_id == 5
-            assert row.league_season_id == 2
-            assert row.subdivision_id_before == 3
-            assert row.subdivision_id_after == 3
+            assert row.league_season_id == 3
+            assert row.subdivision_id_before == 5
+            assert row.subdivision_id_after == 5
             assert row.score_before == 6
             assert row.score_after == 5
             assert row.game_count == 43
@@ -216,8 +216,8 @@ async def test_persist_score_new_player(league_service, database):
 async def test_persist_score_old_player(league_service, database):
     game_id = 10
     old_player_id = 1
-    season_id = 2
-    division_id = 3
+    season_id = 3
+    division_id = 5
     score = 6
     game_count = 42
     returning = True
@@ -237,9 +237,9 @@ async def test_persist_score_old_player(league_service, database):
         for row in rows:
             assert row.game_id == 10
             assert row.login_id == 1
-            assert row.league_season_id == 2
-            assert row.subdivision_id_before == 3
-            assert row.subdivision_id_after == 3
+            assert row.league_season_id == 3
+            assert row.subdivision_id_before == 5
+            assert row.subdivision_id_after == 5
             assert row.score_before == 6
             assert row.score_after == 5
             assert row.game_count == 43
@@ -248,8 +248,8 @@ async def test_persist_score_old_player(league_service, database):
 async def test_persist_score_season_id_mismatch(league_service):
     game_id = 10
     player_id = 1
-    wrong_season_id = 1
-    division_id = 3
+    wrong_season_id = 2
+    division_id = 5
     score = 6
     game_count = 42
     returning = False
@@ -263,8 +263,8 @@ async def test_persist_score_season_id_mismatch(league_service):
 async def test_persist_score_division_without_score(league_service):
     game_id = 10
     player_id = 1
-    season_id = 2
-    division_id = 3
+    season_id = 3
+    division_id = 5
     no_score = None
     game_count = 42
     returning = False

--- a/tests/unit_tests/test_league_service.py
+++ b/tests/unit_tests/test_league_service.py
@@ -121,6 +121,22 @@ async def test_is_returning_player(league_service):
     assert is_returning
 
 
+async def test_is_not_returning_player(league_service):
+    player_id = 2
+    rating_type = "ladder_1v1"
+
+    is_returning = await league_service.is_returning_player(player_id, rating_type)
+
+    assert not is_returning
+
+    player_id = 4
+    rating_type = "global"
+
+    is_returning = await league_service.is_returning_player(player_id, rating_type)
+
+    assert not is_returning
+
+
 async def test_load_score(league_service):
     player_id = 1
     rating_type = "global"

--- a/tests/unit_tests/test_season_generator.py
+++ b/tests/unit_tests/test_season_generator.py
@@ -43,29 +43,29 @@ async def test_generate_season(season_generator, database):
     async with database.acquire() as conn:
         seasons = await conn.execute(select(league_season))
         rows = seasons.fetchall()
-        assert len(rows) == 6
-        assert max(row.season_number for row in rows) == 4
+        assert len(rows) == 7
+        assert max(row.season_number for row in rows) == 5
 
         divisions = await conn.execute(select(league_season_division))
         rows = divisions.fetchall()
-        assert len(rows) == 9
-        new_division_one = await conn.execute(select(league_season_division).where(league_season_division.c.id == 8))
+        assert len(rows) == 11
+        new_division_one = await conn.execute(select(league_season_division).where(league_season_division.c.id == 10))
         row = new_division_one.fetchone()
-        assert row.league_season_id == 6
+        assert row.league_season_id == 7
         assert row.division_index == 1
-        assert row.name_key == "L3D1"
+        assert row.name_key == "L2S1D1"
         assert row.description_key == "second_test_league.season.1_2.division.1"
 
         subdivisions = await conn.execute(select(league_season_division_subdivision))
         rows = subdivisions.fetchall()
-        assert len(rows) == 10
+        assert len(rows) == 12
         new_subdivision = await conn.execute(
             select(league_season_division_subdivision)
-            .where(league_season_division_subdivision.c.league_season_division_id == 8)
+            .where(league_season_division_subdivision.c.league_season_division_id == 10)
         )
         row = new_subdivision.fetchone()
         assert row.subdivision_index == 1
-        assert row.name_key == "L3D1S1"
+        assert row.name_key == "L2S1D1SD1"
         assert row.description_key == "second_test_league.season.1_2.subdivision.1.1"
         assert row.min_rating == 0
         assert row.max_rating == 3000
@@ -78,5 +78,5 @@ async def test_generate_season_only_once(season_generator, database):
     async with database.acquire() as conn:
         seasons = await conn.execute(select(league_season))
         rows = seasons.fetchall()
-        assert len(rows) == 6
-        assert max(row.season_number for row in rows) == 4
+        assert len(rows) == 7
+        assert max(row.season_number for row in rows) == 5


### PR DESCRIPTION
Closes #74

The function that is responsible for determining if a player is "returning" i.e. has been ranked before and thus only needs to play a reduced number of placement games was faulty. It only checked the first db entry instead of all of them. So if someone was not ranked in the first season they have ever played, but were ranked in later seasons, then the league service would think they are a new player and they would have to play the full number of placement games every time.